### PR TITLE
Make a nested call to GitSessionLoad

### DIFF
--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -202,7 +202,7 @@ endfunction
 augroup gitsessions
     autocmd!
     if ! exists("g:gitsessions_disable_auto_load")
-        autocmd VimEnter * :call g:GitSessionLoad()
+        autocmd VimEnter * nested :call g:GitSessionLoad()
     endif
     autocmd BufEnter * :call g:GitSessionUpdate(0)
     autocmd VimLeave * :call g:GitSessionUpdate()


### PR DESCRIPTION
This can fix syntax highlighting for users with this problem:

http://stackoverflow.com/questions/9281438/syntax-highlighting-doesnt-work-after-restore-a-previous-vim-session