### PR TITLE
Merge some changes from forks

### DIFF
--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -203,7 +203,7 @@ endfunction
 augroup gitsessions
     autocmd!
     if ! exists("g:gitsessions_disable_auto_load")
-        autocmd VimEnter * :call g:GitSessionLoad()
+        autocmd VimEnter * nested :call g:GitSessionLoad()
     endif
     autocmd BufEnter * :call g:GitSessionUpdate(0)
     autocmd VimLeave * :call g:GitSessionUpdate()

--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -171,6 +171,8 @@ function! g:GitSessionLoad(...)
     if argc() != 0
         return
     endif
+    :only
+    :tabonly
 
     let l:show_msg = a:0 > 0 ? a:1 : 0
     let l:file = s:session_file(1)


### PR DESCRIPTION
There's already been a discussion of the nested call thing in #12, but I and other have tested it out and seen that it works just fine, so I say it'd be nice to merge upstream. This is the only vim plugin that offers a session-per-git-branch experience, but it's completely broken without this change.

I was looking at other peoples forks and I also saw a nice change someone made where they'd call :only and :tabonly before session load, so session loading would have a clean slate.