### PR TITLE
Add option to enable nested calls for sessions loading

### DIFF
--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -203,7 +203,11 @@ endfunction
 augroup gitsessions
     autocmd!
     if ! exists("g:gitsessions_disable_auto_load")
-        autocmd VimEnter * :call g:GitSessionLoad()
+        if exists("g:gitsessions_use_nested_load")
+            autocmd VimEnter * nested :call g:GitSessionLoad()
+        else
+            autocmd VimEnter * :call g:GitSessionLoad()
+        endif
     endif
     autocmd BufEnter * :call g:GitSessionUpdate(0)
     autocmd VimLeave * :call g:GitSessionUpdate()


### PR DESCRIPTION
This is basically a variation of https://github.com/wting/gitsessions.vim/pull/12 that allows to optionally and explicitly enable nested calls for session loading. This solves syntax highlighting issue for many people.