### PR TITLE
add gitsessions_auto_create_sessions option to automagically create new sessions on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ non-git projects) and previous sessions should automatically be reloaded.
 
 ### Options
 
+#### Automatically create sessions
+
+If you don't want to have to `:GitSaveSession` you can:
+
+    let g:gitsessions_auto_create_sessions = 1
+
+in your .vimrc and a session will be created for you automatically
+on exit if it doesn't already exist. If it does already exist then
+it will be updated on exit as usual.
+
 #### Change sessions save location
 
 Default session directory is `~/.vim/sessions` and can be modified in `.vimrc`:

--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -201,10 +201,12 @@ function! g:GitSessionDelete()
 endfunction
 
 function! g:GitSessionSaveOnExit()
-    if g:gitsessions_auto_create_sessions
-        return GitSessionSave()
-    else
-        return GitSessionUpdate()
+    if s:in_git_repo()
+        if g:gitsessions_auto_create_sessions
+            return GitSessionSave()
+        else
+            return GitSessionUpdate()
+        endif
     endif
 endfunction
 

--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -213,7 +213,11 @@ endfunction
 augroup gitsessions
     autocmd!
     if ! exists("g:gitsessions_disable_auto_load")
-        autocmd VimEnter * :call g:GitSessionLoad()
+        if exists("g:gitsessions_use_nested_load")
+            autocmd VimEnter * nested :call g:GitSessionLoad()
+        else
+            autocmd VimEnter * :call g:GitSessionLoad()
+        endif
     endif
     autocmd BufEnter * :call g:GitSessionUpdate(0)
     autocmd VimLeave * :call g:GitSessionSaveOnExit()

--- a/plugin/gitsessions.vim
+++ b/plugin/gitsessions.vim
@@ -200,13 +200,21 @@ function! g:GitSessionDelete()
     endif
 endfunction
 
+function! g:GitSessionSaveOnExit()
+    if g:gitsessions_auto_create_sessions
+        return GitSessionSave()
+    else
+        return GitSessionUpdate()
+    endif
+endfunction
+
 augroup gitsessions
     autocmd!
     if ! exists("g:gitsessions_disable_auto_load")
         autocmd VimEnter * :call g:GitSessionLoad()
     endif
     autocmd BufEnter * :call g:GitSessionUpdate(0)
-    autocmd VimLeave * :call g:GitSessionUpdate()
+    autocmd VimLeave * :call g:GitSessionSaveOnExit()
 augroup END
 
 command GitSessionSave call g:GitSessionSave()


### PR DESCRIPTION
I always find myself forgetting to `:GitSaveSession` when I start working on something, so this automates it. The default behaviour is unchanged.

Also contains (in 4247ff2) the change from https://github.com/wting/gitsessions.vim/pull/23